### PR TITLE
Integrate JSON-API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "jms/serializer": "Object de- serialization using JMS\\Serializer",
     "doctrine/annotations": "Object de- serialization annotation support",
     "kleijnweb/jwt-bundle": "JWT authentication support",
-    "doctrine/cache": "Caching parsed and resolved Swagger documents"
+    "doctrine/cache": "Caching parsed and resolved Swagger documents",
+    "tobscure/json-api": "For JSON-API integration"
   },
   "require-dev": {
     "phpunit/phpunit": ">=4.1.0",
@@ -56,7 +57,8 @@
     "phpoption/phpoption": ">=1.1.0",
     "fr3d/swagger-assertions": "^0.2.0",
     "satooshi/php-coveralls": "<1.0",
-    "doctrine/cache": "^1.5.0"
+    "doctrine/cache": "^1.5.0",
+    "tobscure/json-api": "^0.2.1"
   },
   "config": {
     "bin-dir": "bin"


### PR DESCRIPTION
https://github.com/kleijnweb/swagger-bundle/issues/56

- [ ] Should allow currently supported serializers (tobscure uses its own serializer)
- [ ] Extra exceptions / status codes (eg Conflict, Unsupported Media Type)
- [ ] JSON-API specific exception handler
- [ ] Use vendor prefix when enabled
- [ ] Extensive functional tests / examples
- [ ] Add config options
- [ ] Update README

Will need php >=5.5.9 which means a BC break...