### PR TITLE
Add missing quotation marks to avoid yaml deprecations warnings

### DIFF
--- a/src/Resources/config/document.yml
+++ b/src/Resources/config/document.yml
@@ -1,4 +1,4 @@
 services:
   swagger.description.repository:
     class: KleijnWeb\PhpApi\Descriptions\Description\Repository
-    arguments: [%swagger.document.base_path%]
+    arguments: ['%swagger.document.base_path%']


### PR DESCRIPTION
I found one non quoted service argument which is deprecated in newer (>=2.8) Symfony versions as described here: http://symfony.com/blog/new-in-symfony-2-8-yaml-deprecations