### PR TITLE
Fix Symfony Routes http scheme

### DIFF
--- a/src/Routing/OpenApiRouteLoader.php
+++ b/src/Routing/OpenApiRouteLoader.php
@@ -96,7 +96,7 @@ class OpenApiRouteLoader extends Loader
                     RequestMeta::ATTRIBUTE_PATH => $pathItem->getPath()
                 ];
 
-                $route = new Route($pathItem->getPath(), $defaults, $this->resolveRequirements($operation));
+                $route = new Route($pathItem->getPath(), $defaults, $this->resolveRequirements($operation), [], '', $description->getSchemes());
                 $route->setMethods($operation->getMethod());
                 $routes->add($this->createRouteId($resource, $pathItem->getPath(), $controllerKey), $route);
             }
@@ -154,7 +154,7 @@ class OpenApiRouteLoader extends Loader
         string $router,
         string $routerController = null
     ): string {
-    
+
         $operationName = $operation->getMethod();
         $diKey         = "$router.$resourceName";
 

--- a/tests/Routing/SwaggerRouteLoaderTest.php
+++ b/tests/Routing/SwaggerRouteLoaderTest.php
@@ -154,6 +154,35 @@ class SwaggerRouteLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldCreateRoutesWithTheCorrectHttpSchemes()
+    {
+        $this->decriptionMock
+            ->expects($this->any())
+            ->method('getPaths')
+            ->willReturn([
+                new Path('/a', [
+                    new Operation(uniqid(), '/a', 'get'),
+                    new Operation(uniqid(), '/a', 'post')
+                ]),
+            ]);
+
+        $this->decriptionMock
+            ->expects($this->any())
+            ->method('getSchemes')
+            ->willReturn(['https', 'http']);
+
+        $routes = $this->loader->load(self::DOCUMENT_PATH);
+
+        $this->assertCount(2, $routes);
+
+        foreach ($routes as $route) {
+            $this->assertEquals(['https', 'http'], $route->getSchemes());
+        }
+    }
+
+    /**
+     * @test
+     */
     public function routeCollectionWillIncludeSeparateRoutesForSubPaths()
     {
         $this->decriptionMock


### PR DESCRIPTION
When using this bundle to create routes automatically from the `swagger.yml` file, we noticed the `schemes` section were not taken into account when generating the Symfony routes.

### Example `yml`:
```
swagger: '2.0'
info:
    title: example title
    description: example description
    version: '0.1'
host: 'example.com'
schemes:
    - https
(...)
```

### The Issue
The symfony routes would NOT have enforced the `https` scheme:

```
$ app/console debug:router

 ------------------------------------------------ -------- -------- ------ -------------------------------
  Name                                             Method   Scheme   Host   Path
 ------------------------------------------------ -------- -------- ------ -------------------------------
  swagger.swagger.payment.messages.post            POST     ANY      ANY    /payment-messages/
  swagger.swagger.payment.messages.paymentid.get   GET      ANY      ANY    /payment-messages/{paymentId}
 ------------------------------------------------ -------- -------- ------ -------------------------------
```


### Expected
 Given the yml above, we should get the correct schemes, like below:
```
$ app/console debug:router
 ------------------------------------------------ -------- -------- ------ -------------------------------
  Name                                             Method   Scheme   Host   Path
 ------------------------------------------------ -------- -------- ------ -------------------------------
  swagger.swagger.payment.messages.post            POST     https    ANY    /payment-messages/
  swagger.swagger.payment.messages.paymentid.get   GET      https    ANY    /payment-messages/{paymentId}
 ------------------------------------------------ -------- -------- ------ -------------------------------
```