### PR TITLE
Fix Fatal error on invalid input

### DIFF
--- a/src/EventListener/Request/RequestProcessor.php
+++ b/src/EventListener/Request/RequestProcessor.php
@@ -108,6 +108,10 @@ class RequestProcessor
             !$operation->hasParameters() && !count((array)$coercedParams) ? null : $coercedParams
         );
 
+        if (!$result->isValid()) {
+            throw new ValidationException($result->getErrorMessages());
+        }
+
         foreach ($coercedParams as $attribute => $value) {
             /** @var ScalarSchema $schema */
             if (($schema = $operation->getParameter($attribute)->getSchema()) instanceof ScalarSchema) {
@@ -125,10 +129,6 @@ class RequestProcessor
         ) {
             $body = $this->hydrator->hydrate($body, $bodyParam->getSchema());
             $request->attributes->set($bodyParam->getName(), $body);
-        }
-
-        if (!$result->isValid()) {
-            throw new ValidationException($result->getErrorMessages());
         }
     }
 }

--- a/tests/unit/EventListener/Request/RequestProcessorTest.php
+++ b/tests/unit/EventListener/Request/RequestProcessorTest.php
@@ -295,6 +295,28 @@ class RequestProcessorTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function willThrowExceptionIfRequestBodyIsNotValid()
+    {
+        $this->hydratorMock->expects($this->never())
+            ->method('hydrate');
+
+        $processor = $this->createProcessor(true, false);
+        $this->expectException(ValidationException::class);
+
+        $processor->process(
+            $this->createRequest(
+                [
+                    RequestMeta::ATTRIBUTE_URI  => '/uri',
+                    RequestMeta::ATTRIBUTE_PATH => '/path',
+                ],
+                json_encode([])
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
     public function willPassNullToValidatorWhenOperationAndRequestHaveNoParams()
     {
         $processor = $this->createProcessor();


### PR DESCRIPTION
# Issue
Request with invalid schema are sent to the hydrator which results in Fatal errors

# Expected
`RequestProcessor` should throw a `ValidationException` before invoking the hydrator.
The client should receive a `400` response