### PR TITLE
MalformedContentException throws 500 instead of 400

### DIFF
--- a/src/Exception/MalformedContentException.php
+++ b/src/Exception/MalformedContentException.php
@@ -13,7 +13,7 @@ namespace KleijnWeb\SwaggerBundle\Exception;
  */
 class MalformedContentException extends \Exception
 {
-    public function __construct($message = "", $code = 400, \Throwable $previous = null)
+    public function __construct($message = "", $code = 400, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/MalformedContentException.php
+++ b/src/Exception/MalformedContentException.php
@@ -13,4 +13,8 @@ namespace KleijnWeb\SwaggerBundle\Exception;
  */
 class MalformedContentException extends \Exception
 {
+    public function __construct($message = "", $code = 400, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Tests/Exception/MalformedContentExceptionTest.php
+++ b/src/Tests/Exception/MalformedContentExceptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace KleijnWeb\SwaggerBundle\Tests\Exception;
+
+use KleijnWeb\SwaggerBundle\Exception\MalformedContentException;
+use PHPUnit_Framework_TestCase;
+
+class MalformedContentExceptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function malformedContentWillThrow400()
+    {
+        $exception = new MalformedContentException();
+
+        $this->assertEquals('400',$exception->getCode());
+    }
+}

--- a/src/Tests/Exception/MalformedContentExceptionTest.php
+++ b/src/Tests/Exception/MalformedContentExceptionTest.php
@@ -1,5 +1,10 @@
-<?php
-
+<?php declare(strict_types = 1);
+/*
+ * This file is part of the KleijnWeb\SwaggerBundle package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace KleijnWeb\SwaggerBundle\Tests\Exception;
 
@@ -15,6 +20,6 @@ class MalformedContentExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = new MalformedContentException();
 
-        $this->assertEquals('400',$exception->getCode());
+        $this->assertEquals('400', $exception->getCode());
     }
 }


### PR DESCRIPTION
Set status code 400 on MalformedContentException