### PR TITLE
Changed isRequired to cannotBeEmpty for cache key.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,13 @@
   "description": "Makes your Swagger definition into a routing and validation spec",
   "autoload": {
     "psr-4": {
-      "KleijnWeb\\SwaggerBundle\\Tests\\": "tests/unit",
-      "KleijnWeb\\SwaggerBundle\\Tests\\Functional\\": "tests/functional",
       "KleijnWeb\\SwaggerBundle\\": "src"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "KleijnWeb\\SwaggerBundle\\Tests\\": "tests/unit",
+      "KleijnWeb\\SwaggerBundle\\Tests\\Functional\\": "tests/functional"
     }
   },
   "keywords": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,5 +26,6 @@
 
     <php>
         <server name="KERNEL_DIR" value="./tests/functional/PetStore/app"/>
+        <server name="KERNEL_CLASS" value="KleijnWeb\SwaggerBundle\Tests\Functional\PetStore\app\TestKernel"/>
     </php>
 </phpunit>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('document')
             ->addDefaultsIfNotSet()
             ->children()
-            ->scalarNode('cache')->isRequired()->defaultFalse()->end()
+            ->scalarNode('cache')->cannotBeEmpty()->defaultFalse()->end()
             ->scalarNode('base_path')->defaultValue('')->end()
             ->end()
             ->end()

--- a/tests/functional/PetStore/app/TestKernel.php
+++ b/tests/functional/PetStore/app/TestKernel.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace KleijnWeb\SwaggerBundle\Tests\Functional\PetStore\app;
+
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -11,10 +13,10 @@ class TestKernel extends Kernel
     public function registerBundles()
     {
         $bundles = [
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new KleijnWeb\SwaggerBundle\KleijnWebSwaggerBundle(),
-            new KleijnWeb\SwaggerBundle\Tests\Functional\PetStore\PetStoreBundle(),
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\MonologBundle\MonologBundle(),
+            new \KleijnWeb\SwaggerBundle\KleijnWebSwaggerBundle(),
+            new \KleijnWeb\SwaggerBundle\Tests\Functional\PetStore\PetStoreBundle(),
         ];
 
         if (0 === strpos($this->getEnvironment(), 'secure')) {


### PR DESCRIPTION
Fixed #113 

In order to get the tests to pass locally, there were some changes that needed to be made. I fixed the test files being loaded in the non-dev autoloader, and also fixed the issue with symfony 4's KernelTestCase.

See the commit messages themselves for more details.