### PR TITLE
Fix "undefined service 'test.client'"

### DIFF
--- a/src/DependencyInjection/InjectTestClientCompilerPass.php
+++ b/src/DependencyInjection/InjectTestClientCompilerPass.php
@@ -18,6 +18,8 @@ class InjectTestClientCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $container->getDefinition('test.client')->setClass('KleijnWeb\SwaggerBundle\Test\ApiTestClient');
+        if ($container->hasDefinition('test.client')) {
+            $container->getDefinition('test.client')->setClass('KleijnWeb\SwaggerBundle\Test\ApiTestClient');
+        }
     }
 }


### PR DESCRIPTION
@kleijnweb When running SwaggerBundle in a production-environment, there's a good chance the test.client service isn't available. I've modified the CompilerPass to make sure it exists prior to setting the class